### PR TITLE
refactor: improve logger construction

### DIFF
--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -57,7 +57,7 @@ var dnsCmd = &cobra.Command{
 		}
 		slog.SetDefault(logger)
 		manager := service.NewManager(5*time.Second, logger)
-		return manager.RunSingleService(ctx, dnsserver.NewService(conf))
+		return manager.RunSingleService(ctx, dnsserver.NewService(conf, logger))
 	},
 }
 

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -38,7 +38,7 @@ var httpCmd = &cobra.Command{
 		manager := service.NewManager(5*time.Second, logger)
 
 		return manager.RunSingleService(ctx,
-			httpserver.NewService(httpserver.Config{Addr: listen, StatusCode: httpStatus}),
+			httpserver.NewService(httpserver.Config{Addr: listen, StatusCode: httpStatus}, logger),
 		)
 	},
 }

--- a/cmd/https.go
+++ b/cmd/https.go
@@ -44,7 +44,7 @@ var httpsCmd = &cobra.Command{
 				Addr:       listen,
 				StatusCode: httpsStatus,
 				TLS:        &tlsprovider.Config{CertFile: httpsCert, KeyFile: httpsKey},
-			}),
+			}, logger),
 		)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,7 @@ var rootCmd = &cobra.Command{
 				TTL:            cfg.DNS.TTL,
 				Compress:       cfg.DNS.Compress,
 			}
-			manager.Add(dnsserver.NewService(conf))
+			manager.Add(dnsserver.NewService(conf, logger))
 		}
 
 		if cfg.HTTP.Enabled {
@@ -82,7 +82,7 @@ var rootCmd = &cobra.Command{
 				return fmt.Errorf("http.listen: %w", err)
 			}
 			conf := httpserver.Config{Addr: listen, StatusCode: cfg.HTTP.Status}
-			manager.Add(httpserver.NewService(conf))
+			manager.Add(httpserver.NewService(conf, logger))
 		}
 
 		if cfg.HTTPS.Enabled {
@@ -95,7 +95,7 @@ var rootCmd = &cobra.Command{
 				StatusCode: cfg.HTTPS.Status,
 				TLS:        &tlsprovider.Config{CertFile: cfg.HTTPS.Cert, KeyFile: cfg.HTTPS.Key},
 			}
-			manager.Add(httpserver.NewService(conf))
+			manager.Add(httpserver.NewService(conf, logger))
 		}
 
 		if cfg.SMTP.Enabled {
@@ -112,7 +112,7 @@ var rootCmd = &cobra.Command{
 				MaxRecipients:     cfg.SMTP.MaxRecipients,
 				AllowInsecureAuth: cfg.SMTP.AllowInsecureAuth,
 			}
-			manager.Add(smtpserver.NewService(conf))
+			manager.Add(smtpserver.NewService(conf, logger))
 		}
 
 		if cfg.SMTPS.Enabled {
@@ -130,7 +130,7 @@ var rootCmd = &cobra.Command{
 				AllowInsecureAuth: cfg.SMTPS.AllowInsecureAuth,
 			}
 			conf.TLS = &tlsprovider.Config{CertFile: cfg.SMTPS.Cert, KeyFile: cfg.SMTPS.Key}
-			manager.Add(smtpserver.NewService(conf))
+			manager.Add(smtpserver.NewService(conf, logger))
 		}
 
 		logger.Info("running", "dns", cfg.DNS.Enabled, "http", cfg.HTTP.Enabled, "https", cfg.HTTPS.Enabled, "smtp", cfg.SMTP.Enabled, "smtps", cfg.SMTPS.Enabled)

--- a/cmd/smtp.go
+++ b/cmd/smtp.go
@@ -51,7 +51,7 @@ var smtpCmd = &cobra.Command{
 				MaxMessageBytes:   smtpMaxMessageBytes,
 				MaxRecipients:     smtpMaxRecipients,
 				AllowInsecureAuth: smtpAllowInsecureAuth,
-			}),
+			}, logger),
 		)
 	},
 }

--- a/cmd/smtps.go
+++ b/cmd/smtps.go
@@ -55,7 +55,7 @@ var smtpsCmd = &cobra.Command{
 				MaxRecipients:     smtpsMaxRecipients,
 				AllowInsecureAuth: smtpsAllowInsecureAuth,
 				TLS:               &tlsprovider.Config{CertFile: smtpsCert, KeyFile: smtpsKey},
-			}),
+			}, logger),
 		)
 	},
 }

--- a/internal/dnsserver/config.go
+++ b/internal/dnsserver/config.go
@@ -20,12 +20,8 @@ type Server struct {
 	log  *slog.Logger
 }
 
-func NewService(conf Config) service.Service {
-	return &Server{conf: conf}
-}
-
-func (s *Server) SetLogger(logger *slog.Logger) {
-	s.log = logger
+func NewService(conf Config, logger *slog.Logger) service.Service {
+	return &Server{conf: conf, log: service.NewPrefixedLogger(logger, "DNS")}
 }
 
 type Config struct {

--- a/internal/dnsserver/dns_test.go
+++ b/internal/dnsserver/dns_test.go
@@ -2,6 +2,8 @@ package dnsserver
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
 	"net"
 	"net/netip"
 	"testing"
@@ -29,7 +31,8 @@ func queryTestsHelper(t *testing.T) (client *dns.Client, addr string, config Con
 		TTL:            60,
 		Compress:       false,
 	}
-	srv, err := NewServer(conf, nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv, err := NewServer(conf, logger)
 	if err != nil {
 		// failed to create server with error
 		_ = pc.Close()

--- a/internal/dnsserver/server.go
+++ b/internal/dnsserver/server.go
@@ -14,9 +14,6 @@ func NewServer(conf Config, logger *slog.Logger) (*dns.Server, error) {
 	if err := conf.validate(); err != nil {
 		return nil, err
 	}
-	if logger == nil {
-		logger = slog.Default()
-	}
 
 	h := &handler{
 		logger:         logger,
@@ -42,9 +39,6 @@ func NewServer(conf Config, logger *slog.Logger) (*dns.Server, error) {
 
 func (s *Server) Start(ctx context.Context) error {
 	logger := s.log
-	if logger == nil {
-		logger = slog.Default().With("service", s.Name())
-	}
 
 	srv, err := NewServer(s.conf, logger)
 	if err != nil {
@@ -95,9 +89,6 @@ type handler struct {
 
 func (h *handler) handle(w dns.ResponseWriter, r *dns.Msg) {
 	logger := h.logger
-	if logger == nil {
-		logger = slog.Default().With("service", "DNS")
-	}
 
 	m := new(dns.Msg)
 	m.SetReply(r)
@@ -138,9 +129,6 @@ func appendRecord(logger *slog.Logger, m *dns.Msg, q dns.Question, ttl uint32, r
 	if rr, err := dns.NewRR(record); err == nil {
 		m.Answer = append(m.Answer, rr)
 	} else {
-		if logger == nil {
-			logger = slog.Default().With("service", "DNS")
-		}
 		logger.Error("failed to create record", "type", rrType, "name", q.Name, "err", err)
 	}
 }

--- a/internal/httpserver/config.go
+++ b/internal/httpserver/config.go
@@ -20,16 +20,12 @@ type Server struct {
 	log     *slog.Logger
 }
 
-func NewService(conf Config) service.Service {
+func NewService(conf Config, logger *slog.Logger) service.Service {
 	name := "HTTP"
 	if conf.TLS != nil {
 		name = "HTTPS"
 	}
-	return &Server{name: name, conf: conf}
-}
-
-func (s *Server) SetLogger(logger *slog.Logger) {
-	s.log = logger
+	return &Server{name: name, conf: conf, log: service.NewPrefixedLogger(logger, name)}
 }
 
 type Config struct {

--- a/internal/httpserver/fakemode.go
+++ b/internal/httpserver/fakemode.go
@@ -80,9 +80,6 @@ func (w *statusCaptureWriter) WriteHeader(code int) {
 
 func (h FakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := h.Logger
-	if logger == nil {
-		logger = slog.Default().With("service", "HTTP")
-	}
 
 	m := resolveFakeMeta(r.URL.Path)
 	gen := defaultFakeRegistry.lookup(m.ext)

--- a/internal/httpserver/http_test.go
+++ b/internal/httpserver/http_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -23,7 +24,8 @@ func TestHTTPServer_Smoke(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 
-	srv, err := NewServer(Config{Addr: "127.0.0.1:0", StatusCode: http.StatusCreated}, nil, nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv, err := NewServer(Config{Addr: "127.0.0.1:0", StatusCode: http.StatusCreated}, nil, logger)
 	if err != nil {
 		// failed to create server with error
 		t.Fatalf("New: %v", err)
@@ -89,7 +91,8 @@ func TestHTTPSServer_Smoke(t *testing.T) {
 		t.Fatalf("GenerateSelfSigned: %v", err)
 	}
 
-	srv, err := NewServer(Config{Addr: "127.0.0.1:0", StatusCode: http.StatusOK}, nil, nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv, err := NewServer(Config{Addr: "127.0.0.1:0", StatusCode: http.StatusOK}, nil, logger)
 	if err != nil {
 		// failed to create https server with error
 		t.Fatalf("New: %v", err)

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -28,9 +28,6 @@ func NewServer(conf Config, handler http.Handler, logger *slog.Logger) (*http.Se
 
 func (s *Server) Start(ctx context.Context) error {
 	logger := s.log
-	if logger == nil {
-		logger = slog.Default().With("service", s.Name())
-	}
 
 	srv, err := NewServer(s.conf, nil, logger)
 	if err != nil {

--- a/internal/service/logger.go
+++ b/internal/service/logger.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// prefix handling system, so prefix for services is display whilst still being able to use lmittman/tint
+type prefixHandler struct {
+	prefix string
+	next   slog.Handler
+}
+
+func (h *prefixHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *prefixHandler) Handle(ctx context.Context, r slog.Record) error {
+	r2 := slog.NewRecord(r.Time, r.Level, h.prefix+r.Message, r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		r2.AddAttrs(a)
+		return true
+	})
+	return h.next.Handle(ctx, r2)
+}
+
+func (h *prefixHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &prefixHandler{prefix: h.prefix, next: h.next.WithAttrs(attrs)}
+}
+
+func (h *prefixHandler) WithGroup(name string) slog.Handler {
+	return &prefixHandler{prefix: h.prefix, next: h.next.WithGroup(name)}
+}
+
+func NewPrefixedLogger(rootLogger *slog.Logger, serviceName string) *slog.Logger {
+	prefix := fmt.Sprintf("%-5s ", strings.ToUpper(serviceName))
+	return slog.New(&prefixHandler{prefix: prefix, next: rootLogger.Handler()})
+}

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -5,37 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 )
-
-// prefix handling system, so prefix for services is display whilst still being able to use lmittman/tint
-type prefixHandler struct {
-	prefix string
-	next   slog.Handler
-}
-
-func (h *prefixHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	return h.next.Enabled(ctx, level)
-}
-
-func (h *prefixHandler) Handle(ctx context.Context, r slog.Record) error {
-	r2 := slog.NewRecord(r.Time, r.Level, h.prefix+r.Message, r.PC)
-	r.Attrs(func(a slog.Attr) bool {
-		r2.AddAttrs(a)
-		return true
-	})
-	return h.next.Handle(ctx, r2)
-}
-
-func (h *prefixHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &prefixHandler{prefix: h.prefix, next: h.next.WithAttrs(attrs)}
-}
-
-func (h *prefixHandler) WithGroup(name string) slog.Handler {
-	return &prefixHandler{prefix: h.prefix, next: h.next.WithGroup(name)}
-}
 
 type Manager struct {
 	services        []Service
@@ -44,9 +16,6 @@ type Manager struct {
 }
 
 func NewManager(shutdownTimeout time.Duration, logger *slog.Logger) *Manager {
-	if logger == nil {
-		logger = slog.Default()
-	}
 	return &Manager{shutdownTimeout: shutdownTimeout, logger: logger}
 }
 
@@ -73,9 +42,6 @@ func runServices(ctx context.Context, logger *slog.Logger, shutdownTimeout time.
 	}
 	if shutdownTimeout <= 0 {
 		shutdownTimeout = 5 * time.Second
-	}
-	if logger == nil {
-		logger = slog.Default()
 	}
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -115,9 +81,6 @@ func runServices(ctx context.Context, logger *slog.Logger, shutdownTimeout time.
 func stopRemaining(logger *slog.Logger, shutdownTimeout time.Duration, services []Service, exited map[Service]bool) {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
-	if logger == nil {
-		logger = slog.Default()
-	}
 
 	var stopWG sync.WaitGroup
 	for _, svc := range services {
@@ -138,14 +101,7 @@ func stopRemaining(logger *slog.Logger, shutdownTimeout time.Duration, services 
 
 func runService(wg *sync.WaitGroup, ctx context.Context, rootLogger *slog.Logger, service Service, exitCh chan<- serviceExit) {
 	defer wg.Done()
-	if rootLogger == nil {
-		rootLogger = slog.Default()
-	}
-	prefix := fmt.Sprintf("%-5s ", strings.ToUpper(service.Name()))
-	logger := slog.New(&prefixHandler{prefix: prefix, next: rootLogger.Handler()})
-	if la, ok := service.(LoggerAware); ok {
-		la.SetLogger(logger)
-	}
+	logger := NewPrefixedLogger(rootLogger, service.Name())
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"log/slog"
 )
 
 type Service interface {
@@ -14,10 +13,4 @@ type Service interface {
 
 	// stop gracefully shuts down the service within the given context deadline
 	Stop(ctx context.Context) error
-}
-
-// optional interface implemented by services that want
-// a logger injected by the service manager
-type LoggerAware interface {
-	SetLogger(logger *slog.Logger)
 }

--- a/internal/smtpserver/config.go
+++ b/internal/smtpserver/config.go
@@ -21,16 +21,12 @@ type Server struct {
 	log  *slog.Logger
 }
 
-func NewService(conf Config) service.Service {
+func NewService(conf Config, logger *slog.Logger) service.Service {
 	name := "SMTP"
 	if conf.TLS != nil {
 		name = "SMTPS"
 	}
-	return &Server{name: name, conf: conf}
-}
-
-func (s *Server) SetLogger(logger *slog.Logger) {
-	s.log = logger
+	return &Server{name: name, conf: conf, log: service.NewPrefixedLogger(logger, name)}
 }
 
 type Config struct {

--- a/internal/smtpserver/server.go
+++ b/internal/smtpserver/server.go
@@ -17,27 +17,16 @@ type errorLogger struct {
 }
 
 func (l errorLogger) Printf(format string, v ...interface{}) {
-	if l.logger == nil {
-		slog.Error("smtp error", "msg", fmt.Sprintf(format, v...))
-		return
-	}
 	l.logger.Error("smtp error", "msg", fmt.Sprintf(format, v...))
 }
 
 func (l errorLogger) Println(v ...interface{}) {
-	if l.logger == nil {
-		slog.Error("smtp error", "msg", fmt.Sprintln(v...))
-		return
-	}
 	l.logger.Error("smtp error", "msg", fmt.Sprintln(v...))
 }
 
 func NewServer(conf Config, logger *slog.Logger) (*smtp.Server, error) {
 	if err := conf.validate(); err != nil {
 		return nil, err
-	}
-	if logger == nil {
-		logger = slog.Default()
 	}
 
 	backend := &Backend{logger: logger}
@@ -66,9 +55,6 @@ func NewServer(conf Config, logger *slog.Logger) (*smtp.Server, error) {
 
 func (s *Server) Start(ctx context.Context) error {
 	logger := s.log
-	if logger == nil {
-		logger = slog.Default().With("service", s.Name())
-	}
 
 	srv, err := NewServer(s.conf, logger)
 	if err != nil {

--- a/internal/smtpserver/smtp_test.go
+++ b/internal/smtpserver/smtp_test.go
@@ -33,7 +33,7 @@ func TestSMTPServer(t *testing.T) {
 		MaxMessageBytes:   1024 * 1024,
 		MaxRecipients:     50,
 		AllowInsecureAuth: true,
-	}, nil)
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}


### PR DESCRIPTION
### Description
<!-- Clear, concise description of what this PR is solving. Focus on the problem and solution, don't focus too much on the implementation -->
<!-- Please replace the placeholder text with your description -->

Improves logger construction by explicitly constructing loggers and removing the `LoggerAware` interface; logging setup is much more concise

### Linked Resources
<!-- Reference linked issues with a hashtag, questions / comments in discussions or on other social media, or any related resources -->
<!-- Please replace the placeholder text with your description -->

*No resources have been linked.*

<!-- Checklist: place an x in each box if it has been completed. -->
<!-- Note that these can be checked or unchecked after PR creation, should you complete these steps later -->
<br/>

> - [x] I have read [CONTRIBUTING.md](github.com/lachlanharrisdev/gonetsim/blob/main/.github/CONTRIBUTING.md)
> - [x] The project builds and runs successfully (i.e. `go run .`)
> - [x] Tests pass locally on my machine (i.e. `go test ./...`)
>   - [x] Relevant tests have been updated / created
>   - [x] Code passes linting checks (i.e. `golangci-lint run`; [install](https://golangci-lint.run/docs/welcome/install/local/))
> - [x] Relevant documentation has been updated / created ([here](github.com/lachlanharrisdev/gonetsim-docs))
