### PR TITLE
fix: undo duplicate dns shutdown logic

### DIFF
--- a/internal/dnsserver/server.go
+++ b/internal/dnsserver/server.go
@@ -42,14 +42,6 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 	s.srv = srv
 
-	go func() {
-		<-ctx.Done()
-		err = s.srv.ShutdownContext(context.Background())
-		if err != nil {
-			logger.Error("failed to shutdown DNS server", "err", err)
-		}
-	}()
-
 	logger.Info("listening", "on", s.conf.Addr, "net", s.conf.Net, "sinkhole", sinkholeSummary(s.conf))
 	if err := srv.ListenAndServe(); err != nil {
 		return err


### PR DESCRIPTION
### Description
<!-- Clear, concise description of what this PR is solving. Focus on the problem and solution, don't focus too much on the implementation -->
<!-- Please replace the placeholder text with your description -->

Undoes a previous "fix" to properly shutdown DNS server; improperly tested and turned out to be unnecessary

### Linked Resources
<!-- Reference linked issues with a hashtag, questions / comments in discussions or on other social media, or any related resources -->
<!-- Please replace the placeholder text with your description -->

*No resources have been linked.*

<!-- Checklist: place an x in each box if it has been completed. -->
<!-- Note that these can be checked or unchecked after PR creation, should you complete these steps later -->
<br/>

> - [x] I have read [CONTRIBUTING.md](github.com/lachlanharrisdev/gonetsim/blob/main/.github/CONTRIBUTING.md)
> - [x] The project builds and runs successfully (i.e. `go run .`)
> - [x] Tests pass locally on my machine (i.e. `go test ./...`)
>   - [x] Relevant tests have been updated / created
>   - [x] Code passes linting checks (i.e. `golangci-lint run`; [install](https://golangci-lint.run/docs/welcome/install/local/))
> - [x] Relevant documentation has been updated / created ([here](github.com/lachlanharrisdev/gonetsim-docs))
