### PR TITLE
feat: add 'requireAuth' config for SMTP

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -126,6 +126,7 @@ var rootCmd = &cobra.Command{
 				ReadTimeout:       cfg.SMTP.ReadTimeout,
 				MaxMessageBytes:   cfg.SMTP.MaxMessageBytes,
 				MaxRecipients:     cfg.SMTP.MaxRecipients,
+				RequireAuth:       cfg.SMTP.RequireAuth,
 				AllowInsecureAuth: cfg.SMTP.AllowInsecureAuth,
 			}
 			if err := conf.Validate(); err != nil {
@@ -147,6 +148,7 @@ var rootCmd = &cobra.Command{
 				ReadTimeout:       cfg.SMTPS.ReadTimeout,
 				MaxMessageBytes:   cfg.SMTPS.MaxMessageBytes,
 				MaxRecipients:     cfg.SMTPS.MaxRecipients,
+				RequireAuth:       cfg.SMTPS.RequireAuth,
 				AllowInsecureAuth: cfg.SMTPS.AllowInsecureAuth,
 			}
 			conf.TLS = &tlsprovider.Config{CertFile: cfg.SMTPS.Cert, KeyFile: cfg.SMTPS.Key}

--- a/cmd/smtp.go
+++ b/cmd/smtp.go
@@ -36,6 +36,7 @@ var smtpCmd = &cobra.Command{
 					ReadTimeout:       cfg.SMTP.ReadTimeout,
 					MaxMessageBytes:   cfg.SMTP.MaxMessageBytes,
 					MaxRecipients:     cfg.SMTP.MaxRecipients,
+					RequireAuth:       cfg.SMTP.RequireAuth,
 					AllowInsecureAuth: cfg.SMTP.AllowInsecureAuth,
 				}
 				if err := conf.Validate(); err != nil {

--- a/cmd/smtps.go
+++ b/cmd/smtps.go
@@ -39,6 +39,7 @@ var smtpsCmd = &cobra.Command{
 					ReadTimeout:       cfg.SMTPS.ReadTimeout,
 					MaxMessageBytes:   cfg.SMTPS.MaxMessageBytes,
 					MaxRecipients:     cfg.SMTPS.MaxRecipients,
+					RequireAuth:       cfg.SMTPS.RequireAuth,
 					AllowInsecureAuth: cfg.SMTPS.AllowInsecureAuth,
 					TLS:               &tlsprovider.Config{CertFile: cfg.SMTPS.Cert, KeyFile: cfg.SMTPS.Key},
 				}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,7 @@ type SMTPConfig struct {
 	ReadTimeout       int    `koanf:"read_timeout"`        // 10 seconds
 	MaxMessageBytes   int    `koanf:"max_message_bytes"`   // 1024 * 1024
 	MaxRecipients     int    `koanf:"max_recipients"`      // 50
+	RequireAuth       bool   `koanf:"require_auth"`        // false
 	AllowInsecureAuth bool   `koanf:"allow_insecure_auth"` // true
 }
 
@@ -84,6 +85,7 @@ type SMTPSConfig struct {
 	ReadTimeout       int    `koanf:"read_timeout"`        // 10 seconds
 	MaxMessageBytes   int    `koanf:"max_message_bytes"`   // 1024 * 1024
 	MaxRecipients     int    `koanf:"max_recipients"`      // 50
+	RequireAuth       bool   `koanf:"require_auth"`        // false
 	AllowInsecureAuth bool   `koanf:"allow_insecure_auth"` // false (secure)
 	Cert              string `koanf:"cert"`                // Optional TLS cert
 	Key               string `koanf:"key"`                 // Optional TLS key
@@ -126,6 +128,7 @@ func Default() Config {
 			ReadTimeout:       10,
 			MaxMessageBytes:   1024 * 1024,
 			MaxRecipients:     50,
+			RequireAuth:       false,
 			AllowInsecureAuth: true,
 		},
 		SMTPS: SMTPSConfig{
@@ -136,6 +139,7 @@ func Default() Config {
 			ReadTimeout:       10,
 			MaxMessageBytes:   1024 * 1024,
 			MaxRecipients:     50,
+			RequireAuth:       false,
 			AllowInsecureAuth: false,
 		},
 		Logging: LoggingConfig{

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -55,6 +55,7 @@ write_timeout = 10
 read_timeout = 10
 max_message_bytes = 1048576
 max_recipients = 50
+require_auth = false
 allow_insecure_auth = true
 
 [smtps]
@@ -65,6 +66,7 @@ write_timeout = 10
 read_timeout = 10
 max_message_bytes = 1048576
 max_recipients = 50
+require_auth = false
 allow_insecure_auth = false
 cert = ""
 key = ""

--- a/internal/smtpserver/config.go
+++ b/internal/smtpserver/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	ReadTimeout       int    // 10 seconds
 	MaxMessageBytes   int    // 1024 * 1024
 	MaxRecipients     int    // 50
+	RequireAuth       bool   // false
 	AllowInsecureAuth bool   // true
 
 	// TLS enables SMTPS mode when non-nil.

--- a/internal/smtpserver/server.go
+++ b/internal/smtpserver/server.go
@@ -25,7 +25,7 @@ func (l errorLogger) Println(v ...interface{}) {
 }
 
 func NewServer(conf Config, logger *slog.Logger) (*smtp.Server, error) {
-	backend := &Backend{logger: logger}
+	backend := &Backend{logger: logger, requireAuth: conf.RequireAuth}
 
 	// Use smtp.NewServer to ensure internal fields like 'done' channel are initialized
 	srv := smtp.NewServer(backend)
@@ -84,24 +84,26 @@ func (s *Server) Stop(ctx context.Context) error {
 
 // Backend implements SMTP server methods.
 type Backend struct {
-	logger *slog.Logger
+	logger      *slog.Logger
+	requireAuth bool
 }
 
 // NewSession is called after client greeting (EHLO, HELO).
 func (bkd *Backend) NewSession(c *smtp.Conn) (smtp.Session, error) {
 	remoteAddr := c.Conn().RemoteAddr().String()
 	bkd.logger.Info("session started", "remote_addr", remoteAddr)
-	return &Session{logger: bkd.logger, remoteAddr: remoteAddr}, nil
+	return &Session{logger: bkd.logger, remoteAddr: remoteAddr, requireAuth: bkd.requireAuth}, nil
 }
 
 // Session represents an SMTP session.
 type Session struct {
-	logger     *slog.Logger
-	remoteAddr string
-	auth       bool
-	username   string
-	from       string
-	recipients []string
+	logger      *slog.Logger
+	remoteAddr  string
+	requireAuth bool
+	auth        bool
+	username    string
+	from        string
+	recipients  []string
 }
 
 // AuthMechanisms returns available authentication mechanisms.
@@ -125,7 +127,7 @@ func (s *Session) Auth(mech string) (sasl.Server, error) {
 
 // Mail handles MAIL FROM command.
 func (s *Session) Mail(from string, opts *smtp.MailOptions) error {
-	if !s.auth {
+	if s.requireAuth && !s.auth {
 		return smtp.ErrAuthRequired
 	}
 	s.from = from
@@ -140,7 +142,7 @@ func (s *Session) Mail(from string, opts *smtp.MailOptions) error {
 
 // Rcpt handles RCPT TO command.
 func (s *Session) Rcpt(to string, opts *smtp.RcptOptions) error {
-	if !s.auth {
+	if s.requireAuth && !s.auth {
 		return smtp.ErrAuthRequired
 	}
 	s.recipients = append(s.recipients, to)
@@ -156,7 +158,7 @@ func (s *Session) Rcpt(to string, opts *smtp.RcptOptions) error {
 
 // Data handles the message data.
 func (s *Session) Data(r io.Reader) error {
-	if !s.auth {
+	if s.requireAuth && !s.auth {
 		return smtp.ErrAuthRequired
 	}
 	b, err := io.ReadAll(r)

--- a/internal/smtpserver/smtp_test.go
+++ b/internal/smtpserver/smtp_test.go
@@ -32,6 +32,7 @@ func TestSMTPServer(t *testing.T) {
 		ReadTimeout:       10,
 		MaxMessageBytes:   1024 * 1024,
 		MaxRecipients:     50,
+		RequireAuth:       true, // this test will use requireauth, smtps test will not
 		AllowInsecureAuth: true,
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
@@ -116,6 +117,7 @@ func TestSMTPSServer(t *testing.T) {
 		ReadTimeout:       10,
 		MaxMessageBytes:   1024 * 1024,
 		MaxRecipients:     50,
+		RequireAuth:       false,
 		AllowInsecureAuth: false,
 	}, logger)
 	if err != nil {


### PR DESCRIPTION
### Description
<!-- Clear, concise description of what this PR is solving. Focus on the problem and solution, don't focus too much on the implementation -->
<!-- Please replace the placeholder text with your description -->

Adds a configuration option `requireAuth`, a boolean determining whether SMTP/S server(s) need authentication before sending mail

### Linked Resources
<!-- Reference linked issues with a hashtag, questions / comments in discussions or on other social media, or any related resources -->
<!-- Please replace the placeholder text with your description -->

*No resources have been linked.*

<!-- Checklist: place an x in each box if it has been completed. -->
<!-- Note that these can be checked or unchecked after PR creation, should you complete these steps later -->
<br/>

> - [x] I have read [CONTRIBUTING.md](github.com/lachlanharrisdev/gonetsim/blob/main/.github/CONTRIBUTING.md)
> - [x] The project builds and runs successfully (i.e. `go run .`)
> - [x] Tests pass locally on my machine (i.e. `go test ./...`)
>   - [x] Relevant tests have been updated / created
>   - [x] Code passes linting checks (i.e. `golangci-lint run`; [install](https://golangci-lint.run/docs/welcome/install/local/))
> - [ ] Relevant documentation has been updated / created ([here](github.com/lachlanharrisdev/gonetsim-docs))
