### PR TITLE
fix: update default to privileged ports

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,11 +43,11 @@ RUN chmod 0755 /gonetsim /entrypoint.sh
 
 WORKDIR /work
 
-EXPOSE 5353/udp
-EXPOSE 5353/tcp
-EXPOSE 8080/tcp
-EXPOSE 8443/tcp
-EXPOSE 1025/tcp
-EXPOSE 1465/tcp
+EXPOSE 53/udp
+EXPOSE 53/tcp
+EXPOSE 80/tcp
+EXPOSE 443/tcp
+EXPOSE 25/tcp
+EXPOSE 465/tcp
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,18 +6,20 @@ services:
 
     # publish the default non-privileged ports
     # to publish standard ports on the host instead, swap to:
-    #  - "53:5353/udp"
-    #  - "53:5353/tcp"
-    #  - "80:8080"
-    #  - "443:8443"
+    #  - "53:53/udp"
+    #  - "53:53/tcp"
+    #  - "80:80"
+    #  - "443:443"
+    #  - "25:25"
+    #  - "465:465"
     # note that updating the configuration file won't change the affected host ports, unlike the standalone binary
     ports:
-      - "5353:5353/udp"
-      - "5353:5353/tcp"
-      - "8080:8080"
-      - "8443:8443"
-      - "1025:1025"
-      - "1465:1465"
+      - "5353:53/udp"
+      - "5353:53/tcp"
+      - "8080:80"
+      - "8443:443"
+      - "1025:25"
+      - "1465:465"
 
     # by default the image includes a config at /etc/gonetsim/gonetsim.toml.
     # to use a custom config, mount a read-only file over it:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,7 @@ type HTTPSConfig struct {
 
 type SMTPConfig struct {
 	Enabled           bool   `koanf:"enabled"`
-	Addr              string `koanf:"addr"`                // ":1025"
+	Addr              string `koanf:"addr"`                // ":25"
 	Domain            string `koanf:"domain"`              // "localhost"
 	WriteTimeout      int    `koanf:"write_timeout"`       // 10 seconds
 	ReadTimeout       int    `koanf:"read_timeout"`        // 10 seconds
@@ -79,7 +79,7 @@ type SMTPConfig struct {
 
 type SMTPSConfig struct {
 	Enabled           bool   `koanf:"enabled"`
-	Addr              string `koanf:"addr"`                // ":1465"
+	Addr              string `koanf:"addr"`                // ":465"
 	Domain            string `koanf:"domain"`              // "localhost"
 	WriteTimeout      int    `koanf:"write_timeout"`       // 10 seconds
 	ReadTimeout       int    `koanf:"read_timeout"`        // 10 seconds
@@ -101,7 +101,7 @@ func Default() Config {
 		General: GeneralConfig{ShutdownTimeout: 2 * time.Second},
 		DNS: DNSConfig{
 			Enabled:  true,
-			Listen:   ":5353",
+			Listen:   ":53",
 			Network:  "udp",
 			IPv4:     "127.0.0.1",
 			IPv6:     "::1",
@@ -112,17 +112,17 @@ func Default() Config {
 		},
 		HTTP: HTTPConfig{
 			Enabled: true,
-			Listen:  ":8080",
+			Listen:  ":80",
 			Status:  200,
 		},
 		HTTPS: HTTPSConfig{
 			Enabled: true,
-			Listen:  ":8443",
+			Listen:  ":443",
 			Status:  200,
 		},
 		SMTP: SMTPConfig{
 			Enabled:           true,
-			Addr:              ":1025",
+			Addr:              ":25",
 			Domain:            "localhost",
 			WriteTimeout:      10,
 			ReadTimeout:       10,
@@ -133,7 +133,7 @@ func Default() Config {
 		},
 		SMTPS: SMTPSConfig{
 			Enabled:           true,
-			Addr:              ":1465",
+			Addr:              ":465",
 			Domain:            "localhost",
 			WriteTimeout:      10,
 			ReadTimeout:       10,

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -20,7 +20,7 @@ shutdown_timeout = "2s"
 
 [dns]
 enabled = true
-listen = ":5353"
+listen = ":53"
 network = "udp"
 # Sinkhole IP for A responses.
 ipv4 = "127.0.0.1"
@@ -37,19 +37,19 @@ compress = false
 
 [http]
 enabled = true
-listen = ":8080"
+listen = ":80"
 # Status code to return for all requests. 0 means default (200).
 status = 200
 
 [https]
 enabled = true
-listen = ":8443"
+listen = ":443"
 # Status code to return for all requests. 0 means default (200).
 status = 200
 
 [smtp]
 enabled = true
-addr = ":1025"
+addr = ":25"
 domain = "localhost"
 write_timeout = 10
 read_timeout = 10
@@ -60,7 +60,7 @@ allow_insecure_auth = true
 
 [smtps]
 enabled = true
-addr = ":1465"
+addr = ":465"
 domain = "localhost"
 write_timeout = 10
 read_timeout = 10


### PR DESCRIPTION
### Description
<!-- Clear, concise description of what this PR is solving. Focus on the problem and solution, don't focus too much on the implementation -->
<!-- Please replace the placeholder text with your description -->

Updates default config to use the privileged ports (i.e. `80` instead of `8080`, `443` instead of `8443`, `25` instead of `1025` etc.)

### Linked Resources
<!-- Reference linked issues with a hashtag, questions / comments in discussions or on other social media, or any related resources -->
<!-- Please replace the placeholder text with your description -->

*No resources have been linked.*

<!-- Checklist: place an x in each box if it has been completed. -->
<!-- Note that these can be checked or unchecked after PR creation, should you complete these steps later -->
<br/>

> - [x] I have read [CONTRIBUTING.md](github.com/lachlanharrisdev/gonetsim/blob/main/.github/CONTRIBUTING.md)
> - [x] The project builds and runs successfully (i.e. `go run .`)
> - [x] Tests pass locally on my machine (i.e. `go test ./...`)
>   - [x] Relevant tests have been updated / created
>   - [x] Code passes linting checks (i.e. `golangci-lint run`; [install](https://golangci-lint.run/docs/welcome/install/local/))
> - [x] Relevant documentation has been updated / created ([here](https://github.com/lachlanharrisdev/gonetsim-docs))
