### PR TITLE
feat: add support for tcp+udp dns listener

### DIFF
--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -58,7 +58,7 @@ func init() {
 	rootCmd.AddCommand(dnsCmd)
 
 	dnsCmd.Flags().String("listen", "", "listen address (overrides config dns.listen)")
-	dnsCmd.Flags().String("network", "", "network: udp or tcp (overrides config dns.network)")
+	dnsCmd.Flags().String("network", "", "network: udp, tcp, or both (overrides config dns.network)")
 	dnsCmd.Flags().String("ipv4", "", "sinkhole IPv4 for A responses (overrides config dns.ipv4)")
 	dnsCmd.Flags().String("ipv6", "", "optional sinkhole IPv6 for AAAA responses (overrides config dns.ipv6)")
 }

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -21,6 +21,7 @@ shutdown_timeout = "2s"
 [dns]
 enabled = true
 listen = ":53"
+# protocol(s) to listen on; "udp", "tcp" or "both"
 network = "udp"
 # Sinkhole IP for A responses.
 ipv4 = "127.0.0.1"

--- a/internal/dnsserver/config.go
+++ b/internal/dnsserver/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/netip"
+	"strings"
 
 	"github.com/miekg/dns"
 
@@ -16,7 +17,7 @@ func (s *Server) Name() string {
 
 type Server struct {
 	conf Config
-	srv  *dns.Server
+	srvs []*dns.Server
 	log  *slog.Logger
 }
 
@@ -42,6 +43,13 @@ func (c Config) Validate() error {
 	}
 	if c.Net == "" {
 		return errors.New("dns network is required")
+	}
+	net := strings.ToLower(strings.TrimSpace(c.Net))
+	switch net {
+	case "udp", "tcp", "both":
+		// all good my boy
+	default:
+		return errors.New("dns network must be one of: udp, tcp, both")
 	}
 	if !c.SinkholeIPv4.IsValid() {
 		return errors.New("dns sinkhole ipv4 is required")

--- a/internal/dnsserver/dns_test.go
+++ b/internal/dnsserver/dns_test.go
@@ -62,6 +62,83 @@ func queryTestsHelper(t *testing.T) (client *dns.Client, addr string, config Con
 	return client, addr, conf, teardown
 }
 
+func queryBothTransportsHelper(t *testing.T) (udpClient *dns.Client, tcpClient *dns.Client, addr string, config Config, teardown func()) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	pc, err := net.ListenPacket("udp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		_ = ln.Close()
+		t.Fatalf("ListenPacket: %v", err)
+	}
+
+	addr = fmt.Sprintf("127.0.0.1:%d", port)
+
+	conf := Config{
+		Addr:           addr,
+		Net:            "both",
+		SinkholeIPv4:   netip.MustParseAddr("203.0.113.10"),
+		SinkholeIPv6:   netip.MustParseAddr("2001:db8::10"),
+		SinkholeDomain: "localhost",
+		SinkholeTXT:    "test",
+		TTL:            60,
+		Compress:       false,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	srvs, err := NewServers(conf, logger)
+	if err != nil {
+		_ = pc.Close()
+		_ = ln.Close()
+		t.Fatalf("NewServers: %v", err)
+	}
+	for _, srv := range srvs {
+		switch srv.Net {
+		case "udp":
+			srv.PacketConn = pc
+		case "tcp":
+			srv.Listener = ln
+		default:
+			_ = pc.Close()
+			_ = ln.Close()
+			t.Fatalf("unexpected server net: %q", srv.Net)
+		}
+	}
+
+	errCh := make(chan error, len(srvs))
+	for _, srv := range srvs {
+		srv := srv
+		go func() {
+			errCh <- srv.ActivateAndServe()
+		}()
+	}
+
+	teardown = func() {
+		for _, srv := range srvs {
+			if err := srv.Shutdown(); err != nil {
+				t.Fatalf("Shutdown: %v", err)
+			}
+		}
+		_ = pc.Close()
+		_ = ln.Close()
+
+		for i := 0; i < len(srvs); i++ {
+			select {
+			case <-errCh:
+			case <-time.After(500 * time.Millisecond):
+			}
+		}
+	}
+
+	udpClient = &dns.Client{Net: "udp", Timeout: 1 * time.Second}
+	tcpClient = &dns.Client{Net: "tcp", Timeout: 1 * time.Second}
+
+	return udpClient, tcpClient, addr, conf, teardown
+}
+
 func TestAQuery(t *testing.T) {
 	client, addr, config, teardown := queryTestsHelper(t)
 	defer teardown()
@@ -239,6 +316,31 @@ func TestCAAQuery(t *testing.T) {
 	if got := caa.Tag; got != "issue" {
 		t.Fatalf("expected tag issue, got %s", got)
 	}
+}
+
+func TestQueryOverUDPAndTCP(t *testing.T) {
+	udpClient, tcpClient, addr, config, teardown := queryBothTransportsHelper(t)
+	defer teardown()
+
+	assertA := func(resp *dns.Msg) {
+		t.Helper()
+		if len(resp.Answer) != 1 {
+			t.Fatalf("expected 1 answer, got %d", len(resp.Answer))
+		}
+		a, ok := resp.Answer[0].(*dns.A)
+		if !ok {
+			t.Fatalf("expected *dns.A, got %T", resp.Answer[0])
+		}
+		if got := a.A.String(); got != config.SinkholeIPv4.String() {
+			t.Fatalf("expected %s, got %s", config.SinkholeIPv4.String(), got)
+		}
+	}
+
+	respUDP := exchange(t, udpClient, addr, "example.com.", dns.TypeA)
+	respTCP := exchange(t, tcpClient, addr, "example.com.", dns.TypeA)
+
+	assertA(respUDP)
+	assertA(respTCP)
 }
 
 func exchange(t *testing.T, client *dns.Client, addr, name string, qtype uint16) *dns.Msg {

--- a/internal/dnsserver/server.go
+++ b/internal/dnsserver/server.go
@@ -10,7 +10,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func NewServer(conf Config, logger *slog.Logger) (*dns.Server, error) {
+func NewServers(conf Config, logger *slog.Logger) ([]*dns.Server, error) {
 	h := &handler{
 		logger:         logger,
 		sinkholeIPv4:   conf.SinkholeIPv4,
@@ -25,35 +25,81 @@ func NewServer(conf Config, logger *slog.Logger) (*dns.Server, error) {
 	mux := dns.NewServeMux()
 	mux.HandleFunc(".", h.handle)
 
-	srv := &dns.Server{
-		Addr:    conf.Addr,
-		Net:     conf.Net,
-		Handler: mux,
+	network := strings.ToLower(strings.TrimSpace(conf.Net))
+	switch network {
+	case "udp", "tcp":
+		return []*dns.Server{{Addr: conf.Addr, Net: network, Handler: mux}}, nil
+	case "both":
+		return []*dns.Server{
+			{Addr: conf.Addr, Net: "udp", Handler: mux},
+			{Addr: conf.Addr, Net: "tcp", Handler: mux},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported dns network %q (must be udp, tcp, or both)", conf.Net)
 	}
-	return srv, nil
+}
+
+func NewServer(conf Config, logger *slog.Logger) (*dns.Server, error) {
+	srvs, err := NewServers(conf, logger)
+	if err != nil {
+		return nil, err
+	}
+	if len(srvs) != 1 {
+		return nil, fmt.Errorf("expected 1 dns server, got %d", len(srvs))
+	}
+	return srvs[0], nil
 }
 
 func (s *Server) Start(ctx context.Context) error {
 	logger := s.log
 
-	srv, err := NewServer(s.conf, logger)
+	srvs, err := NewServers(s.conf, logger)
 	if err != nil {
 		return err
 	}
-	s.srv = srv
+	s.srvs = srvs
 
-	logger.Info("listening", "on", s.conf.Addr, "net", s.conf.Net, "sinkhole", sinkholeSummary(s.conf))
-	if err := srv.ListenAndServe(); err != nil {
-		return err
+	netLabel := strings.ToLower(strings.TrimSpace(s.conf.Net))
+	if netLabel == "both" {
+		netLabel = "udp+tcp"
 	}
-	return nil
+
+	logger.Info("listening", "on", s.conf.Addr, "net", netLabel, "sinkhole", sinkholeSummary(s.conf))
+
+	errCh := make(chan error, len(srvs))
+	for _, srv := range srvs {
+		srv := srv
+		go func() {
+			errCh <- srv.ListenAndServe()
+		}()
+	}
+
+	var retErr error
+	for i := 0; i < len(srvs); i++ {
+		err := <-errCh
+		if err != nil && retErr == nil {
+			retErr = err
+			for _, srv := range srvs {
+				_ = srv.Shutdown()
+			}
+		}
+	}
+	return retErr
 }
 
 func (s *Server) Stop(ctx context.Context) error {
-	if s.srv == nil {
+	if len(s.srvs) == 0 {
 		return nil
 	}
-	return s.srv.ShutdownContext(ctx)
+
+	var firstErr error
+	for _, srv := range s.srvs {
+		if err := srv.ShutdownContext(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	s.srvs = nil
+	return firstErr
 }
 
 func sinkholeSummary(conf Config) string {


### PR DESCRIPTION
### Description
<!-- Clear, concise description of what this PR is solving. Focus on the problem and solution, don't focus too much on the implementation -->
<!-- Please replace the placeholder text with your description -->

The previous DNS listener only had support for listening on either TCP OR UDP. This PR adds a configuration option + flag to have two linked listeners on TCP and UDP simultaneously

### Linked Resources
<!-- Reference linked issues with a hashtag, questions / comments in discussions or on other social media, or any related resources -->
<!-- Please replace the placeholder text with your description -->

*No resources have been linked.*

<!-- Checklist: place an x in each box if it has been completed. -->
<!-- Note that these can be checked or unchecked after PR creation, should you complete these steps later -->
<br/>

> - [x] I have read [CONTRIBUTING.md](github.com/lachlanharrisdev/gonetsim/blob/main/.github/CONTRIBUTING.md)
> - [x] The project builds and runs successfully (i.e. `go run .`)
> - [x] Tests pass locally on my machine (i.e. `go test ./...`)
>   - [x] Relevant tests have been updated / created
>   - [x] Code passes linting checks (i.e. `golangci-lint run`; [install](https://golangci-lint.run/docs/welcome/install/local/))
> - [x] Relevant documentation has been updated / created ([here](https://github.com/lachlanharrisdev/gonetsim-docs))
